### PR TITLE
@beamjet Checkout form html, checkout data validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,18 +186,15 @@ AllPay.prototype.validateCheckout = function(data) {
       if (data['ClientRedirectURL'] == '') { data = _.omit(data, 'ClientRedirectURL'); }
       break;
     case PAYMENT_METHOD.ALIPAY:
-      break;
     case PAYMENT_METHOD.TENPAY:
-      break;
     case PAYMENT_METHOD.TOP_UP_USED:
-      break;
     default:
       errors.push(
         'Payment ' + data['ChoosePayment'] + ' not supported. ' +
-        'Currently support ' + PAYMENT_METHOD.values().join(', ') + '.'
+        'Currently support ' + _.values(PAYMENT_METHOD).join(', ') + '.'
       );
   }
-  return data;
+  return (errors.length > 0) ? errors : data;
 };
 
 AllPay.prototype.checkoutFormHtml = function(data) {

--- a/test/index.js
+++ b/test/index.js
@@ -510,5 +510,19 @@ describe('#validateCheckout', function() {
     //describe('Alipay');
     //describe('Tenpay');
     //describe('TopUpUsed');
+
+    describe('unsupported payment method', function() {
+      beforeEach(function() {
+        required.ChoosePayment = 'P coin';
+      });
+
+      it('returns unsupported errors', function() {
+        var data, results;
+        data = _.extend({}, required);
+
+        results = allPay.validateCheckout(data);
+        results.should.containEql('Payment P coin not supported. Currently support ALL, Credit, WebATM, ATM, CVS, BARCODE, Alipay, Tenpay, TopUpUsed.');
+      });
+    });
   });
 });


### PR DESCRIPTION
You can see the specs for how to use this lib. Let me know if you have any questions.

Current specs:

```
  #initialization
    ✓ has default attribute values for AllPay testing environment 
    ✓ overrides default attribute values with options passed in 

  #genCheckMacValue
    ✓ generates correct Check Mac Value 

  #createFormHtml
    ✓ generates correct HTML form 

  #validateCheckout
    required fields
      ✓ requires MerchantID 
      ✓ requires MerchantID to be no more than 10 chars 
      - requires MerchantTradeNo
      - requires MerchantTradeNo to be no more than 200 chars
      - requires PaymentType
      - requires PaymentType to be "aio"
      - requires TotalAmount
      - requires TradeDesc
      - requires TradeDesc to be no more than 200 chars
      - requires ItemName
      - requires ItemName to be no more than 200 chars
      - requires ReturnURL
      - requires ReturnURL to be no more than 200 chars
      - requires ChoosePayment
      - requires ChoosePayment to be one of the supported payment moethods
    payment methods
      ALL
        ✓ keeps all the required fields 
        ✓ discards invalid options 
        ✓ keeps all options except options of credit card 
        ✓ discards options of ignored payment methods 
        ✓ keeps overlapped fields if not all of the payment methods are ignored 
        ✓ discards ClientRedirectURL option if it is blank 
      Credit
        ✓ keeps all the required fields 
        ✓ returns errors if passed in both installment and periodic options 
        ✓ keeps only installment credit card and ALL options besides required fields 
        ✓ keeps only periodic credit card and ALL options besides required fields 
      WebATM
        ✓ keeps all the required fields 
        ✓ keeps only ALL options besides required fields 
      ATM
        ✓ keeps all the required fields 
        ✓ keeps only ATM and ALL options besides required fields and discards IgnorePayment 
        ✓ discards ClientRedirectURL option if it is blank 
      CVS
        ✓ keeps all the required fields 
        ✓ keeps only CVS and ALL options besides required fields and discards IgnorePayment 
        ✓ discards ClientRedirectURL option if it is blank 
      BARCODE
        ✓ keeps all the required fields 
        ✓ keeps only BARCODE and ALL options besides required fields and discards IgnorePayment 
        ✓ discards ClientRedirectURL option if it is blank 
      unsupported payment method
        ✓ returns unsupported errors 
```
